### PR TITLE
Use io.open in setup.py to support LANG=C.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ the "encodings.idna" module.
 """
 
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup
 import io
 
 version = "0.8"


### PR DESCRIPTION
Opening `README.rst` will fail, if the default encoding is ASCII. Since we know that the file is in fact UTF-8, make that explicit.
