### PR TITLE
Properly report label length exceptions (issue #36)

### DIFF
--- a/idna/core.py
+++ b/idna/core.py
@@ -13,7 +13,7 @@ if sys.version_info[0] == 3:
     unicode = str
     unichr = chr
 
-class IDNAError(UnicodeError):
+class IDNAError(Exception):
     """ Base exception for all IDNA-encoding related problems """
     pass
 

--- a/tests/test_idna.py
+++ b/tests/test_idna.py
@@ -82,6 +82,7 @@ class IDNATests(unittest.TestCase):
 
         self.assertTrue(idna.valid_label_length('a' * 63))
         self.assertFalse(idna.valid_label_length('a' * 64))
+        self.assertRaises(idna.IDNAError, idna.encode, 'a' * 64)
 
     def test_check_bidi(self):
 

--- a/tests/test_idna_uts46.py
+++ b/tests/test_idna_uts46.py
@@ -80,7 +80,7 @@ class TestIdnaTest(unittest.TestCase):
             if to_unicode[0] == u"[":
                 self.fail("decode() did not emit required error")
             self.assertEqual(output, to_unicode, "unexpected decode() output")
-        except (UnicodeError, ValueError) as exc:
+        except (idna.IDNAError, UnicodeError, ValueError) as exc:
             if unicode(exc).startswith(u"Unknown directionality"):
                 raise unittest.SkipTest("Test requires support for a newer"
                     " version of Unicode than this Python supports")
@@ -101,7 +101,7 @@ class TestIdnaTest(unittest.TestCase):
                 self.assertEqual(output, to_ascii,
                     "unexpected encode(transitional={0}) output".
                     format(transitional))
-            except (UnicodeError, ValueError):
+            except (idna.IDNAError, UnicodeError, ValueError):
                 if to_ascii[0] != u"[" and not nv8:
                     raise
 


### PR DESCRIPTION
In Python 3, exceptions were not properly reported due to IDNAError
descending from UnicodeError, using base Exception instead.