### PR TITLE
Fix validation for U+30FB KATAKANA MIDDLE DOT code point

### DIFF
--- a/idna/core.py
+++ b/idna/core.py
@@ -211,9 +211,9 @@ def valid_contexto(label, pos, exception=False):
         for cp in label:
             if cp == u'\u30fb':
                 continue
-            if not _is_script(cp, 'Hiragana') and not _is_script(cp, 'Katakana') and not _is_script(cp, 'Han'):
-                return False
-        return True
+            if _is_script(cp, 'Hiragana') or _is_script(cp, 'Katakana') or _is_script(cp, 'Han'):
+                return True
+        return False
 
     elif 0x660 <= cp_value <= 0x669:
         for cp in label:

--- a/tests/test_idna.py
+++ b/tests/test_idna.py
@@ -225,6 +225,7 @@ class IDNATests(unittest.TestCase):
         self.assertTrue(idna.valid_contexto(katakana + ja_middle_dot + katakana, 1))
         self.assertTrue(idna.valid_contexto(hiragana + ja_middle_dot + hiragana, 1))
         self.assertTrue(idna.valid_contexto(han + ja_middle_dot + han, 1))
+        self.assertTrue(idna.valid_contexto(han + ja_middle_dot + latin, 1))
         self.assertTrue(idna.valid_contexto(u'\u6f22\u30fb\u5b57', 1))
         self.assertFalse(idna.valid_contexto(u'\u0061\u30fb\u0061', 1))
 


### PR DESCRIPTION
The validation now works as described in RFC 5892 Section A.7 -- at least one character in the label besides the dot must be Hiragana, Katakana, or Han. The previous behavior checked that ALL characters in a label were Hiragana, Katakana or Han, which is not right.