### PR TITLE
Check a-label does not contain a trailing hyphen

### DIFF
--- a/idna/core.py
+++ b/idna/core.py
@@ -303,6 +303,8 @@ def ulabel(label):
     label = label.lower()
     if label.startswith(_alabel_prefix):
         label = label[len(_alabel_prefix):]
+        if label.decode('ascii')[-1] == '-':
+            raise IDNAError('A-label must not end with a hyphen')
     else:
         check_label(label)
         return label.decode('ascii')


### PR DESCRIPTION
From RFC5891 § 4.2.1
 "If only an A-label was provided and the conversion to a U-label is
  not performed, the registry MUST still verify that the A-label is
  superficially valid, i.e., that it does not violate any of the rules
  of Punycode encoding [RFC3492] such as the prohibition on trailing
  hyphen-minus, (...)"