### PR TITLE
Remove use of deprecated 'setup.py test' command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ python:
 install:
   - pip install .
 script:
-  - python setup.py test
+  - python -m unittest discover

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ def main():
             'Topic :: Utilities',
         ],
         'python_requires': '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-        'test_suite': 'tests',
     }
 
     setup(**arguments)


### PR DESCRIPTION
Since setuptools v41.5.0 (27 Oct 2019), the 'test' command is formally
deprecated and should not be used. Instead, use the unittest module to
run tests.