### PR TITLE
Added power support for the travis.yml file with ppc64le. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+arch:
+  - amd64
+  - ppc64le
 python:
   - "3.4"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ python:
   - "3.8"
   - "3.9"
   - "pypy3"
+  # Disable unsuported version  pypy for ppc64le
+jobs:
+  exclude:
+
+  - arch: ppc64le
+      python: pypy3
+
 install:
   - pip install .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,11 @@ python:
   - "3.8"
   - "3.9"
   - "pypy3"
-  # Disable unsuported version  pypy for ppc64le
+# Disable unsuported version  pypy for ppc64le
 jobs:
   exclude:
-
   - arch: ppc64le
-      python: pypy3
+    python: pypy3
 
 install:
   - pip install .


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.
excluded job pypy3 on ppc64le. 