### PR TITLE
Drop `universal` `bdist_wheel` option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
The wheel is not `universal` anymore since Python 2 support has been dropped.
The `universal` `bdist_wheel` option was the only one in `setup.cfg` so remove the file.