### PR TITLE
Run GitHub actions on all branches

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,10 +4,8 @@
 name: Python package
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  - push
+  - pull_request
 
 jobs:
   build:


### PR DESCRIPTION
This allows contributors to easily run tests on their fork through
GitHub actions before opening a pull requests.