### PR TITLE
Test with Python 3.11-dev

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev', 'pypy3']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev', 'pypy-3.8']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,11 +19,12 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11-dev'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -35,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev', 'pypy3']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
[Python 3.11.0 beta 1 has been released 🚀](https://discuss.python.org/t/python-3-11-0b1-is-now-available/15602?u=hugovk)

This means it's now time for projects to start testing 3.11:

> We **strongly encourage** maintainers of third-party Python projects to test with 3.11 during the beta phase and report issues found to [the Python bug tracker](https://github.com/python/cpython/issues) as soon as possible. While the release is planned to be feature complete entering the beta phase, it is possible that features may be modified or, in rare cases, deleted up until the start of the release candidate phase (Monday, 2021-08-02). Our goal is have no ABI changes after beta 4 and as few code changes as possible after 3.11.0rc1, the first release candidate. To achieve that, it will be **extremely important** to get as much exposure for 3.11 as possible during the beta phase.

On [GitHub Actions](https://github.com/actions/setup-python#available-versions-of-python), `3.11-dev` tracks the latest available alpha/beta/RC.

---

Let's also bump the actions to the newest `v3`.

And `pypy3` is no longer available and willd fail, we need to use something like `pypy-3.8`.

https://github.com/actions/setup-python#available-versions-of-pypy