### PR TITLE
Create Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it at our [security advisory](https://github.com/kjd/idna/security/advisories/new).
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, vulnerabilities will be disclosed in a best effort base.


### PR DESCRIPTION
Closes #142

I've created the SECURITY.md file following a GitHub's template and considering the [report vulnerability through security advisory](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability), which is a handy new GitHub feature, but it's still in beta and **has to be manually enabled by a maintainer**.

If you're interested in this feature, you can activate it following this steps:

1. Click on this [link](https://github.com/kjd/idna/settings/security_analysis) to go to Code security & analysis section on your repo's settings
2. Click "Enable" for "Private vulnerability reporting (Beta)"

However, if you'd rather not use this feature, you can also request users to report vulnerabilities to an email. If that's the case, let me know which email you would like to receive the reports and I can submit the change.

Additionally, feel free to edit or suggest any changes to this document, it is supposed to reflect the amount of effort the team can offer to handle vulnerabilities.