### PR TITLE
Fix _buffer_encode() wrong return type.

### DIFF
--- a/idna/codec.py
+++ b/idna/codec.py
@@ -26,24 +26,24 @@ class Codec(codecs.Codec):
         return decode(data), len(data)
 
 class IncrementalEncoder(codecs.BufferedIncrementalEncoder):
-    def _buffer_encode(self, data: str, errors: str, final: bool) -> Tuple[str, int]:  # type: ignore
+    def _buffer_encode(self, data: str, errors: str, final: bool) -> Tuple[bytes, int]:
         if errors != 'strict':
             raise IDNAError('Unsupported error handling \"{}\"'.format(errors))
 
         if not data:
-            return "", 0
+            return b'', 0
 
         labels = _unicode_dots_re.split(data)
-        trailing_dot = ''
+        trailing_dot = b''
         if labels:
             if not labels[-1]:
-                trailing_dot = '.'
+                trailing_dot = b'.'
                 del labels[-1]
             elif not final:
                 # Keep potentially unfinished label until the next call
                 del labels[-1]
                 if labels:
-                    trailing_dot = '.'
+                    trailing_dot = b'.'
 
         result = []
         size = 0
@@ -54,9 +54,9 @@ class IncrementalEncoder(codecs.BufferedIncrementalEncoder):
             size += len(label)
 
         # Join with U+002E
-        result_str = '.'.join(result) + trailing_dot  # type: ignore
+        result_bytes = b'.'.join(result) + trailing_dot
         size += len(trailing_dot)
-        return result_str, size
+        return result_bytes, size
 
 class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
     def _buffer_decode(self, data: str, errors: str, final: bool) -> Tuple[str, int]:  # type: ignore

--- a/idna/codec.py
+++ b/idna/codec.py
@@ -59,14 +59,14 @@ class IncrementalEncoder(codecs.BufferedIncrementalEncoder):
         return result_bytes, size
 
 class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
-    def _buffer_decode(self, data: str, errors: str, final: bool) -> Tuple[str, int]:  # type: ignore
+    def _buffer_decode(self, data: bytes, errors: str, final: bool) -> Tuple[str, int]:  # type: ignore
         if errors != 'strict':
             raise IDNAError('Unsupported error handling \"{}\"'.format(errors))
 
         if not data:
             return ('', 0)
 
-        labels = _unicode_dots_re.split(data)
+        labels = data.replace(b'\u3002', b'.').replace(b'\uff0e', b'.').replace(b'\uff61', b'.').split(b'.')
         trailing_dot = ''
         if labels:
             if not labels[-1]:

--- a/tests/test_idna_codec.py
+++ b/tests/test_idna_codec.py
@@ -26,7 +26,7 @@ class IDNACodecTests(unittest.TestCase):
             self.assertEqual("".join(codecs.iterdecode((bytes([c]) for c in encoded), "idna")),
                              decoded)
 
-        decoder = codecs.getincrementaldecoder("idna")()
+        decoder = idna.codec.IncrementalDecoder()
         self.assertEqual(decoder.decode(b"xn--xam", ), "")
         self.assertEqual(decoder.decode(b"ple-9ta.o", ), "\xe4xample.")
         self.assertEqual(decoder.decode(b"rg"), "")
@@ -53,7 +53,7 @@ class IDNACodecTests(unittest.TestCase):
             self.assertEqual(b"".join(codecs.iterencode(decoded, "idna")),
                              encoded)
 
-        encoder = codecs.getincrementalencoder("idna")()
+        encoder = idna.codec.IncrementalEncoder()
         self.assertEqual(encoder.encode("\xe4x"), b"")
         self.assertEqual(encoder.encode("ample.org"), b"xn--xample-9ta.")
         self.assertEqual(encoder.encode("", True), b"org")


### PR DESCRIPTION
Current implementation of _buffer_encode() has the wrong type signature (expected bytes but got str). It also attempts to perform a str.join() on list[bytes].

Fixes #138