### PR TITLE
Include tests in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,4 @@ dynamic = ["version"]
 
 [tool.flit.sdist]
 exclude = [".gitignore", ".github/"]
+include = ["tests"]


### PR DESCRIPTION
Explicitly include tests in sdist archives, as they are used by packagers to test the package.  Tests disappeared in the 3.5 release.