### PR TITLE
Add support for Python 3.13, drop untestable EOL 3.5

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,9 +24,9 @@ jobs:
           - '3.13'
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -53,9 +53,9 @@ jobs:
             os: ubuntu-20.04
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,8 +49,6 @@ jobs:
           - '3.13'
           - 'pypy-3.9'
         include:
-          - python-version: 3.5
-            os: ubuntu-20.04
           - python-version: 3.6
             os: ubuntu-20.04
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,6 +21,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v3
@@ -45,6 +46,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
           - 'pypy-3.9'
         include:
           - python-version: 3.5

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   mypy:
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - '3.8'
@@ -35,6 +36,7 @@ jobs:
 
   build:
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - '3.7'

--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,7 @@ Additional Notes
 * **Packages**. The latest tagged release version is published in the
   `Python Package Index <https://pypi.org/project/idna/>`_.
 
-* **Version support**. This library supports Python 3.5 and higher.
+* **Version support**. This library supports Python 3.6 and higher.
   As this library serves as a low-level toolkit for a variety of
   applications, many of which strive for broad compatibility with older
   Python versions, there is no rush to remove older interpreter support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Internet :: Name Service (DNS)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.5",
   "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
@@ -34,7 +33,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Utilities",
 ]
-requires-python = ">=3.5"
+requires-python = ">=3.6"
 dynamic = ["version"]
 
 [project.urls]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3.12
+  Programming Language :: Python :: 3.13
   Programming Language :: Python :: Implementation :: CPython
   Programming Language :: Python :: Implementation :: PyPy
   Topic :: Internet :: Name Service (DNS)

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
   Programming Language :: Python
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
@@ -30,7 +29,7 @@ classifiers =
   Topic :: Utilities
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.6
 packages=find:
 
 [options.packages.find]


### PR DESCRIPTION
The Python 3.13 release candidate is out now! :rocket:

The Release Manager has issued a [call to action](https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703?u=hugovk]):

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.13 compatibilities during this phase, and where necessary publish Python 3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary wheels built against Python 3.13.0rc1 **will work** with future versions of Python 3.13. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).

This PR also drops support for EOL Python 3.5 because it is no longer testable on GitHub Actions: https://github.com/hugovk/idna/actions/runs/10213551799/job/28259160498

I note 3.6-3.7 are also EOL but this project [strives for broad compatibility](https://github.com/kjd/idna#additional-notes). But lack of CI is a good reason for dropping 3.5 at least.

| cycle |  release   | latest  | latest release |  support   |    eol     |
| :-----| :--------: | :-------| :------------: | :--------: | :--------: |
| 3.12  | 2023-10-02 | 3.12.4  |   2024-06-06   | 2025-04-02 | 2028-10-31 |
| 3.11  | 2022-10-24 | 3.11.9  |   2024-04-02   | 2024-04-01 | 2027-10-31 |
| 3.10  | 2021-10-04 | 3.10.14 |   2024-03-19   | 2023-04-05 | 2026-10-31 |
| 3.9   | 2020-10-05 | 3.9.19  |   2024-03-19   | 2022-05-17 | 2025-10-31 |
| 3.8   | 2019-10-14 | 3.8.19  |   2024-03-19   | 2021-05-03 | 2024-10-31 |
| 3.7   | 2018-06-26 | 3.7.17  |   2023-06-05   | 2020-06-27 | 2023-06-27 |
| 3.6   | 2016-12-22 | 3.6.15  |   2021-09-03   | 2018-12-24 | 2021-12-23 |
| 3.5   | 2015-09-12 | 3.5.10  |   2020-09-05   |   False    | 2020-09-30 |


