### PR TITLE
Fixed check_label

### DIFF
--- a/idna/core.py
+++ b/idna/core.py
@@ -245,6 +245,7 @@ def valid_contexto(label: str, pos: int, exception: bool = False) -> bool:
 def check_label(label: Union[str, bytes, bytearray]) -> None:
     if isinstance(label, (bytes, bytearray)):
         label = label.decode("utf-8")
+    label = label.strip()
     if len(label) == 0:
         raise IDNAError("Empty Label")
 


### PR DESCRIPTION
Fixed whitespace presence when facing domain like "azer-uk.com".

There was a " " in front of the "azer-uk" like : " azer-uk" and was leading to crash