### PR TITLE
Changed the annotated type of data parameter in the encode and decode method

### DIFF
--- a/idna/codec.py
+++ b/idna/codec.py
@@ -8,7 +8,7 @@ _unicode_dots_re = re.compile("[\u002e\u3002\uff0e\uff61]")
 
 
 class Codec(codecs.Codec):
-    def encode(self, data: str, errors: str = "strict") -> Tuple[bytes, int]:
+    def encode(self, data: str | bytes, errors: str = "strict") -> Tuple[bytes, int]:
         if errors != "strict":
             raise IDNAError('Unsupported error handling "{}"'.format(errors))
 
@@ -17,7 +17,7 @@ class Codec(codecs.Codec):
 
         return encode(data), len(data)
 
-    def decode(self, data: bytes, errors: str = "strict") -> Tuple[str, int]:
+    def decode(self, data: str | bytes, errors: str = "strict") -> Tuple[str, int]:
         if errors != "strict":
             raise IDNAError('Unsupported error handling "{}"'.format(errors))
 


### PR DESCRIPTION
In the test_idna.py file, for the `data` parameter of the `decode` method of the `Codec `class, a string value has been passed and accepted but the annotated type is only `bytes`. I have changed the static annotated type to `str|bytes`.

Links for the test file line, where the string values are passed to the  `data` parameter of the `decode` method of the Codec class : 
https://github.com/kjd/idna/blob/cde1d8a4d292b75aa195f0d7a8600be2c26ccedb/tests/test_idna.py#L267
https://github.com/kjd/idna/blob/cde1d8a4d292b75aa195f0d7a8600be2c26ccedb/tests/test_idna.py#L271
https://github.com/kjd/idna/blob/cde1d8a4d292b75aa195f0d7a8600be2c26ccedb/tests/test_idna.py#L275

In the test_idna.py file, for the `data` parameter of the `encode` method of the `Codec `class, a bytes value has been passed  and accepted but the annotated type is only `str`. I have changed the static annotated type to `str|bytes`.

Link for the test file line, where the bytes values are passed to the  `data` parameter of the `encode` method of the Codec class : 
https://github.com/kjd/idna/blob/cde1d8a4d292b75aa195f0d7a8600be2c26ccedb/tests/test_idna.py#L256


