### PR TITLE
Require flit-core v3.11+ to include license file metadata in the distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.11,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
The distributions of the latest release don't include license metadata fields – see https://pypi.org/pypi/idna/json and filter/search for `license` or download the distributions and check `idna-3.10/PKG-INFO` in the source distribution and `idna-3.10-dist-info/METADATA` in the wheel distribution. According to my research, [`flit-core` v3.11+ is needed for writing license file metadata](https://flit.pypa.io/en/latest/pyproject_toml.html#build-system-section), which was published on 2025-02-19, while `idna` v3.10.0 was published on 2024-09-15. As a result,

https://github.com/kjd/idna/blob/cde1d8a4d292b75aa195f0d7a8600be2c26ccedb/pyproject.toml#L9

is omitted from the core metadata of the distributions when built with `flit-core` prior to v3.11. Hence, I've raised the required `flit-core` version to `v3.11+`.

Would you kindly make a quick release after merging this PR, so there's a distribution with license metadata on pypi.org? :bow: