### PR TITLE
Use HTTPS when downloading Unicode data

### DIFF
--- a/tools/idna-data
+++ b/tools/idna-data
@@ -12,8 +12,8 @@ if sys.version_info[0] < 3:
     sys.exit(2)
 
 PREFERRED_VERSION = "16.0.0"
-UCD_URL = "http://www.unicode.org/Public/{version}/ucd/{filename}"
-UTS46_URL = "http://www.unicode.org/Public/idna/{version}/{filename}"
+UCD_URL = "https://www.unicode.org/Public/{version}/ucd/{filename}"
+UTS46_URL = "https://www.unicode.org/Public/idna/{version}/{filename}"
 
 DEFAULT_CACHE_DIR = "~/.cache/unidata"
 


### PR DESCRIPTION
Small change to tools/idna-data: switch UCD_URL and UTS46_URL from http:// to https://. unicode.org has supported HTTPS for a long time, so there's no real reason to keep using plain HTTP here. These URLs are what idna-data uses to pull the UCD and UTS #46 source files, and the result of that download gets baked into the idnadata.py and uts46data.py tables that ship in the published package. Using TLS just removes the chance of a tampered download silently making it into a release if make-libdata ever gets run on a sketchy network. No behavior change for anyone using the library, and only tools/idna-data is touched.