### PR TITLE
Repository housekeeping

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/idna  # Replace <package-name> with your PyPI project name
+      url: https://pypi.org/p/idna
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -64,14 +64,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 -------
 
 3.11 (2025-10-12)
++++++++++++++++++
 
 - Update to Unicode 16.0.0, including significant changes to UTS46
   processing. As a result of Unicode ending support for it, transitional

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2013-2025, Kim Davies and contributors.
+Copyright (c) 2013-2026, Kim Davies and contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Usage
 -----
 
 For typical usage, the ``encode`` and ``decode`` functions will take a
-domain name argument and perform a conversion to ASCII compatible encoding
+domain name argument and perform a conversion to ASCII-compatible encoding
 (known as A-labels), or to Unicode strings (known as U-labels)
 respectively.
 
@@ -159,12 +159,8 @@ Additional Notes
 
 * **Emoji**. It is an occasional request to support emoji domains in
   this library. Encoding of symbols like emoji is expressly prohibited by
-  the technical standard IDNA 2008 and emoji domains are broadly phased
-  out across the domain industry due to associated security risks. For
-  now, applications that need to support these non-compliant labels
-  may wish to consider trying the encode/decode operation in this library
-  first, and then falling back to using `encodings.idna`. See `the Github
-  project <https://github.com/kjd/idna/issues/18>`_ for more discussion.
+  the IDNA technical standard, and emoji domains are broadly phased
+  out across the domain industry due to associated security risks.
 
 * **Transitional processing**. Unicode 16.0.0 removed transitional
   processing so the `transitional` argument for the encode() method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ all = [
     "ruff >= 0.6.2",
     "mypy >= 1.11.2",
     "pytest >= 8.3.2",
-    "flake8 >= 7.1.1",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
- Update copyright year to 2026
- Remove redundant flake8 from CI workflow and optional dependencies (ruff handles linting)
- Update actions/checkout pin in scorecard.yml to match other workflows
- Remove leftover placeholder comment in deploy.yml
- Tidy README wording on ASCII-compatible encoding and emoji domains
- Fix RST formatting of history file