### PR TITLE
Housekeeping and transitional deprecation warning

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  mypy:
+  lint:
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +51,7 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
-          - '3.14-dev'
+          - '3.14'
           - 'pypy-3.9'
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
@@ -65,7 +65,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
         pytest

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,18 @@
 History
 -------
 
+3.12 (2026-04-XX)
++++++++++++++++++
+
+- Update to Unicode 17.0.0
+- Remove the segmentation approach to the data structures that were
+  designed to support Jython since v2.2. Jython only works with Python 2
+  and this library only supports Python 3, so we no longer need to cater
+  to this.
+- Add deprecation warning for the ``transitional`` argument, which no
+  longer has any purpose and will be removed in a future version.
+- Various other tidy-ups, to remove dead code or improve logic.
+
 3.11 (2025-10-12)
 +++++++++++++++++
 

--- a/idna/core.py
+++ b/idna/core.py
@@ -332,13 +332,6 @@ def ulabel(label: Union[str, bytes, bytearray]) -> str:
 
 def uts46_remap(domain: str, std3_rules: bool = True, transitional: bool = False) -> str:
     """Re-map the characters in the string according to UTS46 processing."""
-    if transitional:
-        warnings.warn(
-            "Transitional processing has been removed from UTS #46. "
-            "The transitional argument will be removed in a future version.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
     from .uts46data import uts46data
 
     output = ""

--- a/idna/core.py
+++ b/idna/core.py
@@ -337,25 +337,20 @@ def uts46_remap(domain: str, std3_rules: bool = True, transitional: bool = False
 
     for pos, char in enumerate(domain):
         code_point = ord(char)
-        try:
-            uts46row = uts46data[code_point if code_point < 256 else bisect.bisect_left(uts46data, (code_point, "Z")) - 1]
-            status = uts46row[1]
-            replacement: Optional[str] = None
-            if len(uts46row) == 3:
-                replacement = uts46row[2]
-            if (
-                status == "V"
-                or (status == "D" and not transitional)
-                or (status == "3" and not std3_rules and replacement is None)
-            ):
-                output += char
-            elif replacement is not None and (
-                status == "M" or (status == "3" and not std3_rules) or (status == "D" and transitional)
-            ):
-                output += replacement
-            elif status != "I":
-                raise IndexError()
-        except IndexError:
+        uts46row = uts46data[code_point if code_point < 256 else bisect.bisect_left(uts46data, (code_point, "Z")) - 1]
+        status = uts46row[1]
+        replacement: Optional[str] = None
+        if len(uts46row) == 3:
+            replacement = uts46row[2]
+        if status == "V" or (status == "D" and not transitional) or (status == "3" and not std3_rules and replacement is None):
+            output += char
+        elif replacement is not None and (
+            status == "M" or (status == "3" and not std3_rules) or (status == "D" and transitional)
+        ):
+            output += replacement
+        elif status == "I":
+            continue
+        else:
             raise InvalidCodepoint(
                 "Codepoint {} not allowed at position {} in {}".format(_unot(code_point), pos + 1, repr(domain))
             )

--- a/idna/core.py
+++ b/idna/core.py
@@ -1,6 +1,7 @@
 import bisect
 import re
 import unicodedata
+import warnings
 from typing import Optional, Union
 
 from . import idnadata
@@ -331,6 +332,13 @@ def ulabel(label: Union[str, bytes, bytearray]) -> str:
 
 def uts46_remap(domain: str, std3_rules: bool = True, transitional: bool = False) -> str:
     """Re-map the characters in the string according to UTS46 processing."""
+    if transitional:
+        warnings.warn(
+            "Transitional processing has been removed from UTS #46. "
+            "The transitional argument will be removed in a future version.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     from .uts46data import uts46data
 
     output = ""
@@ -365,6 +373,13 @@ def encode(
     std3_rules: bool = False,
     transitional: bool = False,
 ) -> bytes:
+    if transitional:
+        warnings.warn(
+            "Transitional processing has been removed from UTS #46. "
+            "The transitional argument will be removed in a future version.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     if not isinstance(s, str):
         try:
             s = str(s, "ascii")

--- a/tests/test_idna.py
+++ b/tests/test_idna.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import unittest
+import warnings
 
 import idna
 
@@ -287,6 +288,20 @@ class IDNATests(unittest.TestCase):
             b"A.A.0.a.a.A.0.a.A.A.0.a.A.0A.2.a.A.A.0.a.A.0.A.a.A0.a.a.A.0.a.fB.A.A.a.A.A.B.A.A.a.A.A.B.A.A.a.A.A.0.a.A.a.a.A.A.0.a.A.0.A.a.A0.a.a.A.0.a.fB.A.A.a.A.A.B.0A.A.a.A.A.B.A.A.a.A.A.a.A.A.B.A.A.a.A.0.a.B.A.A.a.A.B.A.a.A.A.5.a.A.0.a.Ba.A.B.A.A.a.A.0.a.Xn--B.A.A.A.a",
         )
         self.assertRaises(idna.IDNAError, decode, b"xn--ukba655qaaaa14431eeaaba.c")
+
+    def test_encode_transitional_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            idna.encode("example.com", uts46=True, transitional=True)
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertIn("transitional", str(w[0].message).lower())
+
+    def test_encode_no_transitional_no_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            idna.encode("example.com", uts46=True)
+            self.assertEqual(len(w), 0)
 
 
 if __name__ == "__main__":

--- a/tools/idna-data
+++ b/tools/idna-data
@@ -7,10 +7,6 @@ from urllib.request import urlopen
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "idna"))
 from intranges import intranges_from_list
 
-if sys.version_info[0] < 3:
-    print("Only Python 3 supported.")
-    sys.exit(2)
-
 PREFERRED_VERSION = "17.0.0"
 UCD_URL = "https://www.unicode.org/Public/{version}/ucd/{filename}"
 UTS46_URL = "https://www.unicode.org/Public/{version}/idna/{filename}"
@@ -18,7 +14,7 @@ UTS46_URL = "https://www.unicode.org/Public/{version}/idna/{filename}"
 DEFAULT_CACHE_DIR = "~/.cache/unidata"
 
 # Scripts affected by IDNA contextual rules
-SCRIPT_WHITELIST = sorted(["Greek", "Han", "Hebrew", "Hiragana", "Katakana"])
+CONTEXT_SCRIPTS = sorted(["Greek", "Han", "Hebrew", "Hiragana", "Katakana"])
 
 UTS46_STATUSES = {
     "valid": ("V", False),
@@ -526,7 +522,7 @@ def idna_libdata(ucdata):
     # Script classifications are used by some CONTEXTO rules in RFC 5891
     #
     yield "scripts = {"
-    for script in SCRIPT_WHITELIST:
+    for script in CONTEXT_SCRIPTS:
         prefix = '    "{}": '.format(script)
         for line in optimised_list(ucdata.ucd_s[script]):
             yield prefix + line
@@ -789,6 +785,7 @@ def uts46_tests(ucdata):
 
 def make_libdata(args, ucdata):
     dest_dir = args.dir or "."
+    test_dir = args.test_dir or dest_dir
 
     target_filename = os.path.join(dest_dir, "idnadata.py")
     with open(target_filename, "wb") as target:
@@ -800,7 +797,7 @@ def make_libdata(args, ucdata):
         for line in uts46_libdata(ucdata):
             target.write((line + "\n").encode("utf-8"))
 
-    target_filename = os.path.join(dest_dir, "test_idna_uts46.py")
+    target_filename = os.path.join(test_dir, "test_idna_uts46.py")
     with open(target_filename, "wb") as target:
         for line in uts46_tests(ucdata):
             target.write((line + "\n").encode("utf-8"))
@@ -821,6 +818,7 @@ def main():
     parser.add_argument("--version", type=str, default="preferred", help="Unicode version to use (preferred, latest, <x.y.z>)")
     parser.add_argument("--source", type=str, default=None, help="Where to fetch Unicode data (file path)")
     parser.add_argument("--dir", type=str, default=None, help="Where to export the output")
+    parser.add_argument("--test-dir", type=str, default=None, help="Where to export test files (defaults to --dir)")
     parser.add_argument("--cache", type=str, default=None, help="Where to cache Unicode data")
     parser.add_argument("--no-cache", action="store_true", help="Don't cache Unicode data")
     libdata = parser.add_argument_group("make-libdata", "Make module data for Python IDNA library")


### PR DESCRIPTION
## Summary

- Add deprecation warning when `transitional=True` is passed to `encode()`, as transitional processing was removed from UTS #46 in Unicode 16.0.0 and the argument no longer has any effect.
- Code quality and CI housekeeping: simplify `uts46_remap` control flow, update CI matrix, clean up dead code in tooling.