### PR TITLE
Reject oversized labels before running Punycode

### DIFF
--- a/idna/core.py
+++ b/idna/core.py
@@ -292,6 +292,14 @@ def alabel(label: str) -> bytes:
     except UnicodeEncodeError:
         pass
 
+    # Punycode never encodes a codepoint into fewer than one output byte, and
+    # the resulting A-label gains a 4-byte "xn--" prefix on top.  Any input
+    # longer than the 63-byte label limit therefore cannot produce a valid
+    # A-label, so reject it before doing the expensive validation and
+    # Punycode encoding work.
+    if not valid_label_length(label):
+        raise IDNAError("Label too long")
+
     check_label(label)
     label_bytes = _alabel_prefix + _punycode(label)
 


### PR DESCRIPTION
Small change in idna/core.py inside alabel(). Right now the non-ASCII path calls check_label() and the Punycode encoder on the full input, and only checks the 63-byte label length afterwards on the encoded result. Since Punycode never compresses the input below its codepoint count, and the encoded A-label always gets a 4-byte 'xn--' prefix on top, anything longer than 63 codepoints is guaranteed to fail the length check no matter what. So we can reject those inputs cheaply up front and avoid running the full validation and encoding work on them. The trailing length check is kept as-is, since shorter inputs can still produce too-long output. No behavior change for valid inputs and the existing test suite (6365 tests) still passes. As a bonus, oversized inputs that would previously chew through hundreds of milliseconds of CPU now fail in microseconds: a 100k codepoint label drops from around 350ms to well under a millisecond on my machine.