### PR TITLE
Type nameprep() as NoReturn

### DIFF
--- a/idna/compat.py
+++ b/idna/compat.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, NoReturn, Union
 
 from .core import decode, encode
 
@@ -11,5 +11,5 @@ def ToUnicode(label: Union[bytes, bytearray]) -> str:
     return decode(label)
 
 
-def nameprep(s: Any) -> None:
+def nameprep(s: Any) -> NoReturn:
     raise NotImplementedError("IDNA 2008 does not utilise nameprep protocol")


### PR DESCRIPTION
Tiny typing fix in idna/compat.py. nameprep() always raises NotImplementedError, so its return annotation should be NoReturn instead of None. This helps mypy and other type checkers correctly understand that the function never returns, which can lead to better narrowing of types in code that calls it. No behavior change at runtime.