### PR TITLE
Raise IDNAError on non-string input to encode/decode

### DIFF
--- a/idna/core.py
+++ b/idna/core.py
@@ -378,6 +378,8 @@ def encode(
             s = str(s, "ascii")
         except UnicodeDecodeError:
             raise IDNAError("should pass a unicode string to the function rather than a byte string.")
+        except TypeError:
+            raise IDNAError("should pass a unicode string or ASCII byte string to the function.")
     if uts46:
         s = uts46_remap(s, std3_rules, transitional)
     trailing_dot = False
@@ -411,11 +413,13 @@ def decode(
     uts46: bool = False,
     std3_rules: bool = False,
 ) -> str:
-    try:
-        if not isinstance(s, str):
+    if not isinstance(s, str):
+        try:
             s = str(s, "ascii")
-    except UnicodeDecodeError:
-        raise IDNAError("Invalid ASCII in A-label")
+        except UnicodeDecodeError:
+            raise IDNAError("Invalid ASCII in A-label")
+        except TypeError:
+            raise IDNAError("should pass a unicode string or ASCII byte string to the function.")
     if uts46:
         s = uts46_remap(s, std3_rules, False)
     trailing_dot = False

--- a/idna/core.py
+++ b/idna/core.py
@@ -376,10 +376,8 @@ def encode(
     if not isinstance(s, str):
         try:
             s = str(s, "ascii")
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, TypeError):
             raise IDNAError("should pass a unicode string to the function rather than a byte string.")
-        except TypeError:
-            raise IDNAError("should pass a unicode string or ASCII byte string to the function.")
     if uts46:
         s = uts46_remap(s, std3_rules, transitional)
     trailing_dot = False
@@ -416,10 +414,8 @@ def decode(
     if not isinstance(s, str):
         try:
             s = str(s, "ascii")
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, TypeError):
             raise IDNAError("Invalid ASCII in A-label")
-        except TypeError:
-            raise IDNAError("should pass a unicode string or ASCII byte string to the function.")
     if uts46:
         s = uts46_remap(s, std3_rules, False)
     trailing_dot = False

--- a/tests/test_idna.py
+++ b/tests/test_idna.py
@@ -303,6 +303,15 @@ class IDNATests(unittest.TestCase):
             idna.encode("example.com", uts46=True)
             self.assertEqual(len(w), 0)
 
+    def test_encode_decode_invalid_input_type(self):
+        # encode() and decode() are documented to raise IDNAError on bad
+        # input.  Inputs that are not str, bytes, or bytes-like used to leak
+        # a raw TypeError out of str(s, "ascii"); they should be wrapped in
+        # IDNAError just like UnicodeDecodeError already is.
+        for value in (42, None, 1.5, ["a", "b"], {"a": 1}):
+            self.assertRaises(idna.IDNAError, idna.encode, value)
+            self.assertRaises(idna.IDNAError, idna.decode, value)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Small fix in idna/core.py. encode() and decode() are typed as accepting Union[str, bytes, bytearray] and the contract is that bad input raises IDNAError. Right now though, if you pass something that isn't str-like or bytes-like at all (an int, None, a float, a list, etc.), the str(s, 'ascii') conversion raises a raw TypeError that escapes through the IDNAError boundary. This means callers who do try / except idna.IDNAError still see uncaught TypeErrors for some inputs. The fix is to also catch TypeError in the same spot we already catch UnicodeDecodeError and re-raise as IDNAError with a clear message about what kind of input was expected. The bytes/bytearray path is untouched, so codec usage that relies on the str(s, 'ascii') conversion (including passing memoryview from the codec machinery) still works exactly as before. Full test suite still passes.