### PR TITLE
Add transitional parameter support to decode() for TR46 consistency

### DIFF
--- a/idna/core.py
+++ b/idna/core.py
@@ -477,6 +477,13 @@ def uts46_remap(domain: str, std3_rules: bool = True, transitional: bool = False
     :raises InvalidCodepoint: If the domain contains a disallowed
         codepoint under the chosen rules.
     """
+    if transitional:
+        warnings.warn(
+            "Transitional processing has been removed from UTS #46. "
+            "The transitional argument will be removed in a future version.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     from .uts46data import uts46data
 
     output = ""
@@ -532,13 +539,6 @@ def encode(
     :raises IDNAError: If the domain is empty, contains an invalid label,
         or exceeds the maximum domain length.
     """
-    if transitional:
-        warnings.warn(
-            "Transitional processing has been removed from UTS #46. "
-            "The transitional argument will be removed in a future version.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
     if not isinstance(s, str):
         try:
             s = str(s, "ascii")
@@ -576,6 +576,7 @@ def decode(
     strict: bool = False,
     uts46: bool = False,
     std3_rules: bool = False,
+    transitional: bool = False,
 ) -> str:
     """Decode an A-label-encoded domain name back to Unicode.
 
@@ -590,6 +591,9 @@ def decode(
     :param uts46: If ``True``, apply UTS #46 mapping before decoding.
     :param std3_rules: Forwarded to :func:`uts46_remap` when ``uts46`` is
         ``True``.
+    :param transitional: Forwarded to :func:`uts46_remap` when ``uts46``
+        is ``True``. Deprecated: emits a :class:`DeprecationWarning` and
+        will be removed in a future version.
     :returns: The decoded domain as a Unicode string.
     :raises IDNAError: If the input is not valid ASCII, contains an
         invalid label, or is empty.
@@ -600,7 +604,7 @@ def decode(
         except (UnicodeDecodeError, TypeError):
             raise IDNAError("Invalid ASCII in A-label")
     if uts46:
-        s = uts46_remap(s, std3_rules, False)
+        s = uts46_remap(s, std3_rules, transitional)
     trailing_dot = False
     result = []
     if not strict:


### PR DESCRIPTION
This change adds support for the transitional parameter in idna.decode() so its TR46 handling is consistent with idna.encode().

At the moment, encode() allows callers to explicitly control transitional vs nontransitional processing, but decode() always uses the default behavior internally. That makes the API slightly asymmetric and also makes it harder for callers working with legacy TR46 flows to apply the same processing mode in both directions.

The change is intentionally small and backward compatible:

- adds transitional=False to decode()
- passes the value through to uts46_remap()
- centralizes the existing deprecation warning logic inside uts46_remap() so warnings behave consistently for all callers

I also ran the existing test suite to verify there were no regressions.