### PR TITLE
Add early length validation in check_label

### DIFF
--- a/idna/core.py
+++ b/idna/core.py
@@ -352,6 +352,17 @@ def check_label(label: Union[str, bytes, bytearray]) -> None:
         label = label.decode("utf-8")
     if len(label) == 0:
         raise IDNAError("Empty Label")
+    # Reject oversized labels before per-codepoint validation runs.
+    # CONTEXTJ/CONTEXTO checks scan the whole label per codepoint, so an
+    # uncapped label drives validation into quadratic time
+    # (GHSA-65pc-fj4g-8rjx / CVE-2024-3651). encode()/decode() cap the
+    # whole-domain length; this cap protects direct callers of
+    # alabel/ulabel/check_label and the idna2008 incremental codec.
+    # Use the whole-domain bound rather than the per-label DNS bound so
+    # that UTS #46 lenient decoding of labels longer than 63 chars is
+    # preserved.
+    if not valid_string_length(label, trailing_dot=True):
+        raise IDNAError("Label too long")
 
     check_nfc(label)
     check_hyphen_ok(label)

--- a/tests/test_idna.py
+++ b/tests/test_idna.py
@@ -95,6 +95,30 @@ class IDNATests(unittest.TestCase):
             self.assertRaises(idna.IDNAError, idna.decode, payload)
             self.assertLess(time.perf_counter() - start, 1.0)
 
+    def test_oversized_label_rejected_promptly(self):
+        # The whole-domain cap in encode()/decode() does not cover direct
+        # callers of alabel/ulabel/check_label, nor the idna2008
+        # incremental codec which calls alabel/ulabel per label. Without a
+        # per-label cap, a single oversized CONTEXTO-heavy label still
+        # drives validation into quadratic time.
+        import codecs
+        import time
+
+        import idna.codec  # noqa: F401  (register the idna2008 codec)
+
+        payload = "・" * 8000 + "漢"
+        start = time.perf_counter()
+        self.assertRaises(idna.IDNAError, idna.check_label, payload)
+        self.assertRaises(idna.IDNAError, idna.alabel, payload)
+        self.assertRaises(idna.IDNAError, idna.ulabel, payload)
+        self.assertRaises(
+            idna.IDNAError,
+            codecs.getincrementalencoder("idna2008")().encode,
+            payload,
+            True,
+        )
+        self.assertLess(time.perf_counter() - start, 1.0)
+
     def test_check_bidi(self):
         la = "\u0061"
         r = "\u05d0"


### PR DESCRIPTION
Oversized labels can still reach expensive contextual validation through
lower-level label-processing entry points such as:
- alabel()
- ulabel()
- check_label()
- the incremental idna2008 codec

CONTEXTJ/CONTEXTO validation may scan the full label repeatedly so very large attacker-controlled labels can drive pathological O(n²) processing.

This patch adds an early length guard in check_label(), the shared validation path used by all label-processing APIs, rejecting oversized labels before expensive validation executes.

The implementation uses valid_string_length(..., trailing_dot=True) to preserve existing UTS #46 lenient handling behavior while still bounding worst-case processing time.

Tests are added to verify prompt rejection across:
- check_label()
- alabel()
- ulabel()
- the incremental idna2008 codec