### PR TITLE
check domain length before uts46_remap in encode and decode

### DIFF
--- a/idna/core.py
+++ b/idna/core.py
@@ -12,6 +12,14 @@ _alabel_prefix = b"xn--"
 _unicode_dots_re = re.compile("[\u002e\u3002\uff0e\uff61]")
 
 
+# Loose sanity cap applied before uts46_remap. The exact DNS limit (254) is
+# enforced after remapping, since mapping can both grow and shrink the string;
+# this only exists to keep pathological inputs out of the superlinear NFC
+# normalization in uts46_remap, so it is set an order of magnitude above the
+# real limit to avoid rejecting input that legitimately maps down to size.
+_max_preremap_length = 2540
+
+
 # Bidi category sets from RFC 5893, hoisted out of the per-codepoint loop
 _bidi_rtl_first = frozenset({"R", "AL"})
 _bidi_rtl_categories = frozenset({"R", "AL", "AN"})
@@ -522,17 +530,17 @@ def encode(
             s = str(s, "ascii")
         except (UnicodeDecodeError, TypeError) as err:
             raise IDNAError("should pass a unicode string to the function rather than a byte string.") from err
-    # Reject inputs that exceed the maximum DNS domain length up-front to
-    # avoid expensive computation on long inputs. This runs before
-    # uts46_remap because its NFC normalization is superlinear on adversarial
-    # combining-mark sequences; checking afterwards lets such input through.
-    if not valid_string_length(s, trailing_dot=True):
+    # Bound the input before uts46_remap so its superlinear NFC normalization
+    # cannot be driven into pathological time by an oversized adversarial
+    # string. This is a loose cap, not the DNS limit, since mapping may shrink
+    # the string; the exact length is enforced after remapping below.
+    if len(s) > _max_preremap_length:
         raise IDNAError("Domain too long")
 
     if uts46:
         s = uts46_remap(s, std3_rules, transitional)
-        if not valid_string_length(s, trailing_dot=True):
-            raise IDNAError("Domain too long")
+    if not valid_string_length(s, trailing_dot=True):
+        raise IDNAError("Domain too long")
 
     trailing_dot = False
     result = []
@@ -584,16 +592,16 @@ def decode(
             s = str(s, "ascii")
         except (UnicodeDecodeError, TypeError) as err:
             raise IDNAError("Invalid ASCII in A-label") from err
-    # Reject inputs that exceed the maximum DNS domain length up-front to
-    # avoid expensive computation on long inputs. This runs before
-    # uts46_remap because its NFC normalization is superlinear on adversarial
-    # combining-mark sequences; checking afterwards lets such input through.
-    if not valid_string_length(s, trailing_dot=True):
+    # Bound the input before uts46_remap so its superlinear NFC normalization
+    # cannot be driven into pathological time by an oversized adversarial
+    # string. This is a loose cap, not the DNS limit, since mapping may shrink
+    # the string; the exact length is enforced after remapping below.
+    if len(s) > _max_preremap_length:
         raise IDNAError("Domain too long")
     if uts46:
         s = uts46_remap(s, std3_rules, False)
-        if not valid_string_length(s, trailing_dot=True):
-            raise IDNAError("Domain too long")
+    if not valid_string_length(s, trailing_dot=True):
+        raise IDNAError("Domain too long")
     trailing_dot = False
     result = []
     labels = s.split(".") if strict else _unicode_dots_re.split(s)

--- a/idna/core.py
+++ b/idna/core.py
@@ -522,13 +522,17 @@ def encode(
             s = str(s, "ascii")
         except (UnicodeDecodeError, TypeError) as err:
             raise IDNAError("should pass a unicode string to the function rather than a byte string.") from err
-    if uts46:
-        s = uts46_remap(s, std3_rules, transitional)
-
-    # Reject inputs that exceed the maximum DNS domain length up-front
-    # to avoid expensive computation on long inputs.
+    # Reject inputs that exceed the maximum DNS domain length up-front to
+    # avoid expensive computation on long inputs. This runs before
+    # uts46_remap because its NFC normalization is superlinear on adversarial
+    # combining-mark sequences; checking afterwards lets such input through.
     if not valid_string_length(s, trailing_dot=True):
         raise IDNAError("Domain too long")
+
+    if uts46:
+        s = uts46_remap(s, std3_rules, transitional)
+        if not valid_string_length(s, trailing_dot=True):
+            raise IDNAError("Domain too long")
 
     trailing_dot = False
     result = []
@@ -580,12 +584,16 @@ def decode(
             s = str(s, "ascii")
         except (UnicodeDecodeError, TypeError) as err:
             raise IDNAError("Invalid ASCII in A-label") from err
-    if uts46:
-        s = uts46_remap(s, std3_rules, False)
-    # Reject inputs that exceed the maximum DNS domain length up-front
-    # to avoid expensive computation on long inputs.
+    # Reject inputs that exceed the maximum DNS domain length up-front to
+    # avoid expensive computation on long inputs. This runs before
+    # uts46_remap because its NFC normalization is superlinear on adversarial
+    # combining-mark sequences; checking afterwards lets such input through.
     if not valid_string_length(s, trailing_dot=True):
         raise IDNAError("Domain too long")
+    if uts46:
+        s = uts46_remap(s, std3_rules, False)
+        if not valid_string_length(s, trailing_dot=True):
+            raise IDNAError("Domain too long")
     trailing_dot = False
     result = []
     labels = s.split(".") if strict else _unicode_dots_re.split(s)

--- a/tests/test_idna.py
+++ b/tests/test_idna.py
@@ -94,6 +94,19 @@ class IDNATests(unittest.TestCase):
             self.assertRaises(idna.IDNAError, idna.decode, payload)
             self.assertLess(time.perf_counter() - start, 1.0)
 
+    def test_oversized_uts46_input_rejected_promptly(self):
+        # The whole-domain cap must run before uts46_remap(), whose NFC
+        # normalization is superlinear on long combining-mark runs. Without an
+        # up-front guard, oversized input fed through uts46=True drives that
+        # normalization into quadratic time before any length check applies.
+        import time
+
+        payload = "a" + "̖̣̗́" * 50000
+        start = time.perf_counter()
+        self.assertRaises(idna.IDNAError, idna.encode, payload, uts46=True)
+        self.assertRaises(idna.IDNAError, idna.decode, payload, uts46=True)
+        self.assertLess(time.perf_counter() - start, 1.0)
+
     def test_oversized_label_rejected_promptly(self):
         # The whole-domain cap in encode()/decode() does not cover direct
         # callers of alabel/ulabel/check_label, nor the idna2008


### PR DESCRIPTION
The oversize-domain guard in encode and decode runs after uts46_remap, but that remap performs an NFC normalization whose canonical reordering goes quadratic on long combining-mark runs. An attacker-controlled string passed with uts46=True is therefore fully normalized before the length check rejects it: roughly 200 KB takes about 2.5s here, while the same input with uts46=False is dropped instantly. This moves the length check ahead of uts46_remap and re-checks afterwards, since mapping can still lengthen the string.