### PR TITLE
cap A-label length before punycode decode in ulabel

### DIFF
--- a/idna/core.py
+++ b/idna/core.py
@@ -419,6 +419,11 @@ def ulabel(label: Union[str, bytes, bytearray]) -> str:
         check_label(label_bytes)
         return label_bytes.decode("ascii")
 
+    # check_label enforces the DNS-length cap only after the Punycode decode
+    # below, which is quadratic in its input, so bound the A-label here first.
+    if not valid_string_length(label_bytes, trailing_dot=True):
+        raise IDNAError("A-label too long")
+
     try:
         label = label_bytes.decode("punycode")
     except UnicodeError as err:

--- a/tests/test_idna.py
+++ b/tests/test_idna.py
@@ -118,6 +118,29 @@ class IDNATests(unittest.TestCase):
         )
         self.assertLess(time.perf_counter() - start, 1.0)
 
+    def test_oversized_alabel_rejected_promptly(self):
+        # ulabel() Punycode-decodes an A-label before check_label can apply
+        # its length cap, so the per-label cap does not protect against an
+        # oversized xn-- label whose decode runs in quadratic time. alabel
+        # (via its ASCII fast path) and the idna2008 incremental decoder
+        # both reach the same decode.
+        import codecs
+        import time
+
+        import idna.codec  # register the idna2008 codec
+
+        payload = "xn--" + "a" * 100000
+        start = time.perf_counter()
+        self.assertRaises(idna.IDNAError, idna.ulabel, payload)
+        self.assertRaises(idna.IDNAError, idna.alabel, payload)
+        self.assertRaises(
+            idna.IDNAError,
+            codecs.getincrementaldecoder("idna2008")().decode,
+            payload.encode("ascii"),
+            True,
+        )
+        self.assertLess(time.perf_counter() - start, 1.0)
+
     def test_check_bidi(self):
         la = "\u0061"
         r = "\u05d0"


### PR DESCRIPTION
check_label's per-label length cap runs after the Punycode decode in ulabel, so an oversized xn-- A-label still decodes in quadratic time before the cap rejects it (around 0.5s for a 120k-octet label). alabel reaches the same decode through its ASCII fast path, and the idna2008 incremental decoder calls ulabel per label, so neither is covered by the up-front guard in encode/decode. Cap the A-label length before decoding.